### PR TITLE
Simplifiy BOARD_ROOT directory path

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -3,12 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 set(BOARD scsat1_main)
-
-get_filename_component(APPLICATION_PROJECT_DIR
-                       ${CMAKE_CURRENT_LIST_DIR}/../
-                       ABSOLUTE
-)
-set(BOARD_ROOT ${APPLICATION_PROJECT_DIR})
+set(BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR}/..)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(scsat1-main)

--- a/tests/hwtest/adcs/CMakeLists.txt
+++ b/tests/hwtest/adcs/CMakeLists.txt
@@ -3,12 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 set(BOARD scsat1_adcs)
-
-get_filename_component(APPLICATION_PROJECT_DIR
-                       ${CMAKE_CURRENT_LIST_DIR}/../../../
-                       ABSOLUTE
-)
-set(BOARD_ROOT ${APPLICATION_PROJECT_DIR})
+set(BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../../)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(scsat1-adcs)

--- a/tests/hwtest/main/CMakeLists.txt
+++ b/tests/hwtest/main/CMakeLists.txt
@@ -3,12 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 set(BOARD scsat1_main)
-
-get_filename_component(APPLICATION_PROJECT_DIR
-                       ${CMAKE_CURRENT_LIST_DIR}/../../../
-                       ABSOLUTE
-)
-set(BOARD_ROOT ${APPLICATION_PROJECT_DIR})
+set(BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../../)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(scsat1-main)


### PR DESCRIPTION
BOARD_ROOT must be an absolute path but not a "canonical" path. having multiple ".." is stil an absolute path.  Thus, we don't need to use get_filename_component() to get a canonical path.