### PR TITLE
drivers: dstrx3: Fix implicit conversion from float to double

### DIFF
--- a/zephyr/drivers/misc/sc_dstrx3.c
+++ b/zephyr/drivers/misc/sc_dstrx3.c
@@ -129,7 +129,7 @@ int sc_dstrx3_get_hk_telemetry(const struct device *dev, struct sc_dstrx3_hk *hk
 	LOG_DBG("RSSI             : %d", hk->rssi);
 	LOG_DBG("RCV_FREQ         : %d", hk->rcv_freq);
 	LOG_DBG("TEMPERATURE      : %d", hk->temperature);
-	LOG_DBG("VOLTAGE          : %f [v] (raw: %d)", (float)((hk->voltage / 256) * 2.5),
+	LOG_DBG("VOLTAGE          : %f [v] (raw: %d)", (double)(hk->voltage / 256.0f * 2.5f),
 		hk->voltage);
 	LOG_DBG("TX_PWR           : %d", hk->tx_power);
 	LOG_DBG("CARRIER_LOCK     : %d", hk->carrier_lock);


### PR DESCRIPTION
In C, a literal value like `2.5` is considered a `double`. When you multiply a `float` by a `double`, implicit promotion occurs, performing the calculation in 64 bits. This unnecessarily consumes CPU power on MCUs.

```
[116/166] Building C object modules/scsat1-fsw/drivers/misc/CMakeFiles/..__scsat1-fsw__zephyr__drivers__misc.dir/sc_dstrx3.c.obj
In file included from /home/yashi/work/spacecubics/launch2022/scsat1-fsw/workspace/zephyr/include/zephyr/logging/log.h:11,
                 from /home/yashi/work/spacecubics/launch2022/scsat1-fsw/workspace/scsat1-fsw/zephyr/drivers/misc/sc_dstrx3.c:9:
/home/yashi/work/spacecubics/launch2022/scsat1-fsw/workspace/scsat1-fsw/zephyr/drivers/misc/sc_dstrx3.c: In function 'sc_dstrx3_get_hk_telemetry':
/home/yashi/work/spacecubics/launch2022/scsat1-fsw/workspace/scsat1-fsw/zephyr/drivers/misc/sc_dstrx3.c:132:56: warning: implicit conversion from 'float' to 'double' when passing argument to function [-Wdouble-promotion]
  132 |         LOG_DBG("VOLTAGE          : %f [v] (raw: %d)", (float)((hk->voltage / 256) * 2.5),
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/yashi/work/spacecubics/launch2022/scsat1-fsw/workspace/zephyr/include/zephyr/logging/log_core.h:166:32: note: in definition of macro 'Z_LOG_TO_PRINTK'
  166 |                              ##__VA_ARGS__); \
      |                                ^~~~~~~~~~~

```

The goal is to perform all calculations under `float`. Then, for this particular case, convert it to `double` because the value is passed to a variadic function, `z_log_minimal_printk()`.

Related resources:
- https://en.cppreference.com/w/c/language/conversion
- Link to PR: https://github.com/zephyrproject-rtos/zephyr/pull/57154