### PR TITLE
.github: workflow: Simplify the build test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,65 +6,51 @@ on:
   schedule:
     - cron: '0 21 * * *' # Run it every day at 9pm UTC
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   simple-build:
     runs-on: ubuntu-22.04
-    if: github.repository == 'spacecubics/scsat1-fsw'
-    container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.26.1
-      options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
-    env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.0
-      ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-    steps:
-      - name: Apply container owner mismatch workaround
-        run: |
-          # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not
-          #        match the container user UID because of the way GitHub
-          #        Actions runner is implemented. Remove this workaround when
-          #        GitHub comes up with a fundamental fix for this problem.
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      matrix:
+        target:
+          - bootloader
+          - main
+          - adcs
+          - tests/hwtest/main
+          - tests/hwtest/adcs
+        python-version:
+          - '3.9'
+          - '3.10'
+          - '3.11'
 
-      - name: Update PATH for west
+    steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Python version
         run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          python3 --version
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          path: scsat1-fsw
 
-      - name: Configure Git
-        run: |
-          git config --global user.email github@spacecubics.com
-          git config --global user.name "Github Actions"
+      - name: Setup Zephyr
+        uses: zephyrproject-rtos/action-zephyr-setup@v1
+        with:
+          app-path: scsat1-fsw
+          toolchains: arm-zephyr-eabi
 
-      - name: Setup Git (pull request)
-        if: ${{ github.base_ref }}
-        env:
-          BASE_REF: ${{ github.base_ref }}
+      - name: Build
         run: |
-          git rebase origin/${BASE_REF}
-          git checkout -b this_pr
+          west build scsat1-fsw/${{ matrix.target }}
 
-      - name: West Setup
-        run: |
-          west init -l . || true
-          west config --global update.narrow true
-          west config --global build.board_warn false
-          west update 2>&1 1> west.update.log || west update 2>&1 1> west.update.log
-
-      - name: Build the PR
-        run: |
-          west build -d build-boot bootloader
-          west build -d build-main main
-          west build -d build-adcs adcs
-          west build -d build-hwtest-main tests/hwtest/main
-          west build -d build-hwtest-adcs tests/hwtest/adcs
+  status-check:
+    runs-on: ubuntu-latest
+    needs: simple-build
+    steps:
+      - name: All test passed
+        run: echo Ready to merge


### PR DESCRIPTION
By using zephyrproject-rtos/action-zephyr-setup, we can simplify our build test.