### PR TITLE
hwtest/tools: Add DSTRX-3 parameters to be parsed

### DIFF
--- a/tests/hwtest/tools/parse_main.py
+++ b/tests/hwtest/tools/parse_main.py
@@ -55,6 +55,19 @@ TARGET_LIST = [
     "Ping to ADCS Board:[ms]",
     "Ping to Payload Board:[ms]",
     "Payload Board JPEG Count:[cnt]",
+    "DSTRX-3 HK FREE_COUNTER     :[cnt]",
+    "DSTRX-3 HK WDT_COUNTER      :[cnt]",
+    "DSTRX-3 HK RSSI             :[dBm]",
+    "DSTRX-3 HK RCV_FREQ         :[Hz]",
+    "DSTRX-3 HK TEMPERATURE      :[deg]",
+    "DSTRX-3 HK VOLTAGE          :[v]",
+    "DSTRX-3 HK TX_PWR           :[dBm]",
+    "DSTRX-3 HK CARRIER_LOCK     :[bool]",
+    "DSTRX-3 HK SUB_CARRIER_LOCK :[bool]",
+    "DSTRX-3 HK TX_PWR_SET       :[dBm]",
+    "DSTRX-3 HK BIT_RATE_SET     :[bps]",
+    "DSTRX-3 HK PROG_NO          :[num]",
+    "DSTRX-3 HK CHK_SUM          :[num]",
 ]
 
 x_data = {}


### PR DESCRIPTION
- Summary
This change is to read the HK telemetry data of DSTRX-3 and output it as CSV files or PDF files. This was added because DSTRX-3 is connected to the Main OBC and can now read data.

- Scope of impact
The impact of this change is the addition of outputting CSV files recording DSTRX-3's HK telemetry and adding some graphs to the PDF files.

- Notice
The added part follows the descriptions of other components, but it looks different from other descriptions because DSTRX's telemetry data contains a fixed number of spaces, so the same number of spaces is added to avoid changes in the control code section.