### PR TITLE
boards,zephyr/driver/can: Remove sjw in dts

### DIFF
--- a/boards/arm/scsat1_adcs/scsat1_adcs.dts
+++ b/boards/arm/scsat1_adcs/scsat1_adcs.dts
@@ -61,7 +61,6 @@
 			interrupts = <5 0>;
 			reg = <0x40400000 0x10000>;
 			bus-speed = <1000000>;
-			sjw = <4>;
 			sample-point = <750>;
 			tx-fifo-depth = <64>;
 			max-filter = <4>;

--- a/boards/arm/scsat1_main/scsat1_main.dts
+++ b/boards/arm/scsat1_main/scsat1_main.dts
@@ -55,7 +55,6 @@
 			interrupts = <5 0>;
 			reg = <0x40400000 0x10000>;
 			bus-speed = <1000000>;
-			sjw = <4>;
 			sample-point = <750>;
 			tx-fifo-depth = <64>;
 			max-filter = <4>;
@@ -71,7 +70,6 @@
 			interrupts = <19 0>;
 			reg = <0x50100000 0x10000>;
 			bus-speed = <1000000>;
-			sjw = <4>;
 			sample-point = <750>;
 			tx-fifo-depth = <64>;
 			max-filter = <4>;
@@ -87,7 +85,6 @@
 			interrupts = <20 0>;
 			reg = <0x50200000 0x10000>;
 			bus-speed = <1000000>;
-			sjw = <4>;
 			sample-point = <750>;
 			tx-fifo-depth = <64>;
 			max-filter = <4>;

--- a/zephyr/drivers/can/can_sccan.c
+++ b/zephyr/drivers/can/can_sccan.c
@@ -170,7 +170,6 @@ struct sc_can_cfg {
 	uint32_t reg_addr;
 	irq_init_func_t irq_init;
 	uint32_t clock_frequency;
-	uint8_t sjw;
 	uint8_t tx_fifo_depth;
 	uint8_t max_filter;
 };
@@ -1051,7 +1050,6 @@ static int sc_can_init(const struct device *dev)
 	uint32_t v;
 
 	/* Set timing according to dts default setting */
-	timing.sjw = config->sjw;
 	ret = can_calc_timing(dev, &timing, config->common.bus_speed, config->common.sample_point);
 	if (ret == -EINVAL) {
 		LOG_ERR("Can't find timing for given param");
@@ -1159,7 +1157,6 @@ static const struct can_driver_api sc_can_driver_api = {
 		.reg_addr = DT_INST_REG_ADDR(n),                                                   \
 		.irq_init = sc_can_##n##_irq_init,                                                 \
 		.clock_frequency = DT_INST_PROP(n, clock_frequency),                               \
-		.sjw = DT_INST_PROP(n, sjw),                                                       \
 		.tx_fifo_depth = DT_INST_PROP(n, tx_fifo_depth),                                   \
 		.max_filter = DT_INST_PROP(n, max_filter),                                         \
 	};                                                                                         \


### PR DESCRIPTION
In the Zephyr CAN common driver, automatic calculation of SJW was already implemented below commit.

  - e397b85 drivers: can: calculate a default SJW value

Therefore, deprecated SJW settings were removed commit below, and this commit also removes from the SC CAN driver.

  - 0c13f38 dts: bindings: can: remove deprecated properties for initial timing