### PR TITLE
hwtest/main,adcs: Change default test on auto run

### DIFF
--- a/tests/hwtest/adcs/src/main.c
+++ b/tests/hwtest/adcs/src/main.c
@@ -133,7 +133,7 @@ int main(void)
 
 		k_sleep(K_SECONDS(30));
 
-		shell_execute_cmd(shell_backend_uart_get_ptr(), "hwtest loop -1");
+		shell_execute_cmd(shell_backend_uart_get_ptr(), "hwtest syshk -1");
 	}
 
 	return 0;

--- a/tests/hwtest/main/src/main.c
+++ b/tests/hwtest/main/src/main.c
@@ -136,7 +136,7 @@ int main(void)
 
 		k_sleep(K_SECONDS(150));
 
-		shell_execute_cmd(shell_backend_uart_get_ptr(), "hwtest loop -1");
+		shell_execute_cmd(shell_backend_uart_get_ptr(), "hwtest syshk -1");
 	}
 
 	return 0;


### PR DESCRIPTION
This commit change the default test from `loop` to `syshk` on auto run test.