### PR TITLE
hwtest/main: Fix the erroneous error detected in test mode 0

### DIFF
--- a/tests/hwtest/main/src/syshk_test.c
+++ b/tests/hwtest/main/src/syshk_test.c
@@ -126,6 +126,12 @@ static int one_loop(uint32_t *err_cnt)
 	struct all_test_result test_ret;
 	static uint32_t loop_count = 0;
 
+	/*
+	 * The tests in CSP have some that are not conducted depending on
+	 * the test mode, so all result fields are initialized to 0.
+	 */
+	memset(&csp_ret, 0, sizeof(csp_ret));
+
 	LOG_INF("===[Temp Test Start (total err: %d)]===", *err_cnt);
 	ret = temp_test(&temp_ret, err_cnt, LOG_DISABLE);
 	if (ret < 0) {


### PR DESCRIPTION
When running the test in test mode 0 (MAIN Board only), it will detect errors in the CSP related to ADCS/PYLOD, which should not have been conducted.

This is because the initialization of the test result structure has not been performed, so all result fields are initialized to 0.