### PR TITLE
hwtest/main,adcs: Fix unexpected stop on loop test

### DIFF
--- a/tests/hwtest/adcs/src/common.h
+++ b/tests/hwtest/adcs/src/common.h
@@ -8,15 +8,16 @@
 
 #include <zephyr/logging/log.h>
 
-#define CSP_ID_MAIN     (1U)
-#define CSP_ID_ADCS     (2U)
-#define CSP_ID_PYLD     (3U)
-#define CSP_ID_EPS      (4U)
-#define CSP_ID_SRS3     (5U)
-#define CSP_ID_GND      (10U)
-#define LOOP_STOP_EVENT (1U)
-#define LOG_ENABLE      (true)
-#define LOG_DISABLE     (false)
+#define CSP_ID_MAIN      (1U)
+#define CSP_ID_ADCS      (2U)
+#define CSP_ID_PYLD      (3U)
+#define CSP_ID_EPS       (4U)
+#define CSP_ID_SRS3      (5U)
+#define CSP_ID_GND       (10U)
+#define LOOP_START_EVENT (0U)
+#define LOOP_STOP_EVENT  (1U)
+#define LOG_ENABLE       (true)
+#define LOG_DISABLE      (false)
 
 #define HWTEST_LOG_INF(log, format, ...)                                                           \
 	if (log) {                                                                                 \

--- a/tests/hwtest/adcs/src/main.c
+++ b/tests/hwtest/adcs/src/main.c
@@ -66,9 +66,11 @@ static void cmd_handler(void *p1, void *p2, void *p3)
 	} else if (strcmp(cmd, "rw") == 0) {
 		ret = rw_test(&err_cnt);
 	} else if (strcmp(cmd, "loop") == 0) {
+		k_event_set(&loop_event, LOOP_START_EVENT);
 		ret = loop_test(atoi(arg), &err_cnt);
 		k_event_clear(&loop_event, LOOP_STOP_EVENT);
 	} else if (strcmp(cmd, "syshk") == 0) {
+		k_event_set(&loop_event, LOOP_START_EVENT);
 		ret = syshk_test(atoi(arg), &err_cnt);
 		k_event_clear(&loop_event, LOOP_STOP_EVENT);
 	} else {

--- a/tests/hwtest/main/src/common.h
+++ b/tests/hwtest/main/src/common.h
@@ -8,9 +8,10 @@
 
 #include <zephyr/logging/log.h>
 
-#define LOOP_STOP_EVENT (1U)
-#define LOG_ENABLE      (true)
-#define LOG_DISABLE     (false)
+#define LOOP_START_EVENT (0U)
+#define LOOP_STOP_EVENT  (1U)
+#define LOG_ENABLE       (true)
+#define LOG_DISABLE      (false)
 
 enum hwtest_mode {
 	MAIN_ONLY_WITHOUT_DSTRX = 0,

--- a/tests/hwtest/main/src/main.c
+++ b/tests/hwtest/main/src/main.c
@@ -74,9 +74,11 @@ static void cmd_handler(void *p1, void *p2, void *p3)
 	} else if (strcmp(cmd, "dstrx3") == 0) {
 		ret = dstrx3_test(&dstrx3_ret, &err_cnt, LOG_ENABLE);
 	} else if (strcmp(cmd, "loop") == 0) {
+		k_event_set(&loop_event, LOOP_START_EVENT);
 		ret = loop_test(atoi(arg), &err_cnt);
 		k_event_clear(&loop_event, LOOP_STOP_EVENT);
 	} else if (strcmp(cmd, "syshk") == 0) {
+		k_event_set(&loop_event, LOOP_START_EVENT);
 		ret = syshk_test(atoi(arg), &err_cnt);
 		k_event_clear(&loop_event, LOOP_STOP_EVENT);
 	} else {


### PR DESCRIPTION
This commit fixes an issue where the loop test would unexpectedly stop, such as when the stop command is executed twice.