### PR TITLE
Fix board name

### DIFF
--- a/adcs/CMakeLists.txt
+++ b/adcs/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(BOARD scobc_module1)
+set(BOARD scsat1_adcs)
+set(BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR}/..)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(scsat1-adcs)

--- a/drivers/misc/CMakeLists.txt
+++ b/drivers/misc/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2024 Space Cubics, LLC.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_SC_DSTRX3 sc_dstrx3.c)
 
 # Export sc_dstrx3.h temporarily


### PR DESCRIPTION
This commit fixes the board name for SC-Sat1 ADCS.