### PR TITLE
dts: Rename bus-speed property for CAN driver

### DIFF
--- a/boards/sc/scsat1_adcs/scsat1_adcs.dts
+++ b/boards/sc/scsat1_adcs/scsat1_adcs.dts
@@ -60,7 +60,7 @@
 			clock-frequency = <24000000>;
 			interrupts = <5 0>;
 			reg = <0x40400000 0x10000>;
-			bus-speed = <1000000>;
+			bitrate = <1000000>;
 			sample-point = <750>;
 			tx-fifo-depth = <64>;
 			max-filter = <4>;

--- a/boards/sc/scsat1_main/scsat1_main.dts
+++ b/boards/sc/scsat1_main/scsat1_main.dts
@@ -54,7 +54,7 @@
 			clock-frequency = <24000000>;
 			interrupts = <5 0>;
 			reg = <0x40400000 0x10000>;
-			bus-speed = <1000000>;
+			bitrate = <1000000>;
 			sample-point = <750>;
 			tx-fifo-depth = <64>;
 			max-filter = <4>;
@@ -69,7 +69,7 @@
 			clock-frequency = <24000000>;
 			interrupts = <19 0>;
 			reg = <0x50100000 0x10000>;
-			bus-speed = <1000000>;
+			bitrate = <1000000>;
 			sample-point = <750>;
 			tx-fifo-depth = <64>;
 			max-filter = <4>;
@@ -84,7 +84,7 @@
 			clock-frequency = <24000000>;
 			interrupts = <20 0>;
 			reg = <0x50200000 0x10000>;
-			bus-speed = <1000000>;
+			bitrate = <1000000>;
 			sample-point = <750>;
 			tx-fifo-depth = <64>;
 			max-filter = <4>;


### PR DESCRIPTION
This commit is related to ad96a126a. According to the change from 'bus-speed' to 'bitrate,' the property in the DTS will also be renamed.