### PR TITLE
Fix device init on dstrx3 driver

### DIFF
--- a/drivers/misc/dstrx3/sc_dstrx3.c
+++ b/drivers/misc/dstrx3/sc_dstrx3.c
@@ -170,13 +170,13 @@ static void sc_dstrx3_enable_irq(const struct device *dev)
 	cfg->irq_init(dev);
 }
 
-static void sc_dstrx3_enable_hk(const struct device *dev)
+void sc_dstrx3_enable_hk(const struct device *dev)
 {
 	const struct sc_dstrx3_cfg *cfg = dev->config;
 	sys_set_bit(cfg->base + SC_DSTRX3_CS_OFFSET, SC_DSTRX3_HKIF_EN_BIT);
 }
 
-static void sc_dstrx3_enable_cmdif(const struct device *dev)
+void sc_dstrx3_enable_cmdif(const struct device *dev)
 {
 	const struct sc_dstrx3_cfg *cfg = dev->config;
 	sys_set_bit(cfg->base + SC_DSTRX3_CS_OFFSET, SC_DSTRX3_CMIF_EN_BIT);
@@ -184,12 +184,7 @@ static void sc_dstrx3_enable_cmdif(const struct device *dev)
 
 static int sc_dstrx3_init(const struct device *dev)
 {
-	const struct sc_dstrx3_cfg *cfg = dev->config;
-
 	sc_dstrx3_enable_irq(dev);
-	sc_dstrx3_enable_hk(dev);
-	sc_dstrx3_enable_cmdif(dev);
-	sc_dstrx3_set_tx_param(dev, cfg->tx_power, cfg->bit_rate);
 
 	return 0;
 }

--- a/drivers/misc/dstrx3/sc_dstrx3.c
+++ b/drivers/misc/dstrx3/sc_dstrx3.c
@@ -176,10 +176,22 @@ void sc_dstrx3_enable_hk(const struct device *dev)
 	sys_set_bit(cfg->base + SC_DSTRX3_CS_OFFSET, SC_DSTRX3_HKIF_EN_BIT);
 }
 
+void sc_dstrx3_disable_hk(const struct device *dev)
+{
+	const struct sc_dstrx3_cfg *cfg = dev->config;
+	sys_clear_bit(cfg->base + SC_DSTRX3_CS_OFFSET, SC_DSTRX3_HKIF_EN_BIT);
+}
+
 void sc_dstrx3_enable_cmdif(const struct device *dev)
 {
 	const struct sc_dstrx3_cfg *cfg = dev->config;
 	sys_set_bit(cfg->base + SC_DSTRX3_CS_OFFSET, SC_DSTRX3_CMIF_EN_BIT);
+}
+
+void sc_dstrx3_disable_cmdif(const struct device *dev)
+{
+	const struct sc_dstrx3_cfg *cfg = dev->config;
+	sys_clear_bit(cfg->base + SC_DSTRX3_CS_OFFSET, SC_DSTRX3_CMIF_EN_BIT);
 }
 
 static int sc_dstrx3_init(const struct device *dev)

--- a/drivers/misc/dstrx3/sc_dstrx3.c
+++ b/drivers/misc/dstrx3/sc_dstrx3.c
@@ -152,6 +152,12 @@ void sc_dstrx3_set_tx_param(const struct device *dev, enum sc_dstrx3_tx_power tx
 	LOG_DBG("CMTX: 0x%08x", sys_read32(cfg->base + SC_DSTRX3_CMTX_OFFSET));
 }
 
+void sc_dstrx3_set_default_tx_param(const struct device *dev)
+{
+	const struct sc_dstrx3_cfg *cfg = dev->config;
+	sc_dstrx3_set_tx_param(dev, cfg->tx_power, cfg->bit_rate);
+}
+
 static void sc_dstrx3_isr(const struct device *dev)
 {
 	uint32_t isr;

--- a/drivers/misc/dstrx3/sc_dstrx3.h
+++ b/drivers/misc/dstrx3/sc_dstrx3.h
@@ -52,7 +52,9 @@ enum sc_dstrx3_bit_rate {
 };
 
 void sc_dstrx3_enable_hk(const struct device *dev);
+void sc_dstrx3_disable_hk(const struct device *dev);
 void sc_dstrx3_enable_cmdif(const struct device *dev);
+void sc_dstrx3_disable_cmdif(const struct device *dev);
 int sc_dstrx3_get_hk_telemetry(const struct device *dev, struct sc_dstrx3_hk *hk);
 void sc_dstrx3_set_tx_param(const struct device *dev, enum sc_dstrx3_tx_power tx_power,
 			    enum sc_dstrx3_bit_rate bit_rate);

--- a/drivers/misc/dstrx3/sc_dstrx3.h
+++ b/drivers/misc/dstrx3/sc_dstrx3.h
@@ -58,3 +58,4 @@ void sc_dstrx3_disable_cmdif(const struct device *dev);
 int sc_dstrx3_get_hk_telemetry(const struct device *dev, struct sc_dstrx3_hk *hk);
 void sc_dstrx3_set_tx_param(const struct device *dev, enum sc_dstrx3_tx_power tx_power,
 			    enum sc_dstrx3_bit_rate bit_rate);
+void sc_dstrx3_set_default_tx_param(const struct device *dev);

--- a/drivers/misc/dstrx3/sc_dstrx3.h
+++ b/drivers/misc/dstrx3/sc_dstrx3.h
@@ -51,6 +51,8 @@ enum sc_dstrx3_bit_rate {
 	SC_DSTRX3_BIT_RATE_64K,
 };
 
+void sc_dstrx3_enable_hk(const struct device *dev);
+void sc_dstrx3_enable_cmdif(const struct device *dev);
 int sc_dstrx3_get_hk_telemetry(const struct device *dev, struct sc_dstrx3_hk *hk);
 void sc_dstrx3_set_tx_param(const struct device *dev, enum sc_dstrx3_tx_power tx_power,
 			    enum sc_dstrx3_bit_rate bit_rate);

--- a/tests/hwtest/main/src/main_init.c
+++ b/tests/hwtest/main/src/main_init.c
@@ -43,7 +43,7 @@ int main_init(enum hwtest_mode mode, uint32_t *err_cnt)
 	k_sleep(K_SECONDS(1));
 
 	if (mode > MAIN_ONLY_WITHOUT_DSTRX) {
-		sc_main_power_enable(DSTRX_IO_PWR);
+		sc_main_dstrx3_io_power_enable();
 		LOG_INF("Power on the DSTRX-3 IO");
 
 		k_sleep(K_SECONDS(1));
@@ -84,7 +84,7 @@ int main_off(uint32_t *err_cnt)
 
 	k_sleep(K_SECONDS(1));
 
-	sc_main_power_disable(DSTRX_IO_PWR);
+	sc_main_dstrx3_io_power_disable();
 	LOG_INF("Power off the DSTRX-3 IO");
 
 	k_sleep(K_SECONDS(1));

--- a/tests/hwtest/main/src/pwrctrl.c
+++ b/tests/hwtest/main/src/pwrctrl.c
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr/kernel.h>
+#include "sc_dstrx3.h"
+#include "pwrctrl.h"
 
 /* Registers */
 #define SC_MAIN_SYSREG_BASE_ADDR (0x4F000000)
@@ -37,4 +39,23 @@ void sc_main_power_cycle_req(void)
 {
 	sys_write32(SC_MAIN_PWRCYCLEPKC | SC_MAIN_PWRCYCLEREQ,
 		    SC_MAIN_SYSREG_BASE_ADDR + SC_MAIN_PWRCYCLE);
+}
+
+void sc_main_dstrx3_io_power_enable(void)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(dstrx));
+
+	sc_main_power_enable(DSTRX_IO_PWR);
+	sc_dstrx3_enable_hk(dev);
+	sc_dstrx3_enable_cmdif(dev);
+	sc_dstrx3_set_default_tx_param(dev);
+}
+
+void sc_main_dstrx3_io_power_disable(void)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(dstrx));
+
+	sc_dstrx3_disable_cmdif(dev);
+	sc_dstrx3_disable_hk(dev);
+	sc_main_power_disable(DSTRX_IO_PWR);
 }

--- a/tests/hwtest/main/src/pwrctrl.c
+++ b/tests/hwtest/main/src/pwrctrl.c
@@ -22,6 +22,9 @@
 #define SC_MAIN_PWRCYCLEPKC (0x5A5A << 16)
 #define SC_MAIN_PWRCYCLEREQ (1U)
 
+/* Wait time after DSTRX-IO power-on */
+#define SC_MAIN_WAIT_TIME_FOR_DSTRX_IO K_MSEC(10)
+
 void sc_main_power_enable(uint8_t target_bit)
 {
 	sys_set_bits(SC_MAIN_MAIN_BASE_ADDR + SC_MAIN_PCR_OFFSET, SC_MAIN_PCR_KEYCODE | target_bit);
@@ -48,6 +51,7 @@ void sc_main_dstrx3_io_power_enable(void)
 	sc_main_power_enable(DSTRX_IO_PWR);
 	sc_dstrx3_enable_hk(dev);
 	sc_dstrx3_enable_cmdif(dev);
+	k_sleep(SC_MAIN_WAIT_TIME_FOR_DSTRX_IO);
 	sc_dstrx3_set_default_tx_param(dev);
 }
 

--- a/tests/hwtest/main/src/pwrctrl.h
+++ b/tests/hwtest/main/src/pwrctrl.h
@@ -18,3 +18,5 @@
 void sc_main_power_enable(uint8_t target_bit);
 void sc_main_power_disable(uint8_t target_bit);
 void sc_main_power_cycle_req(void);
+void sc_main_dstrx3_io_power_enable(void);
+void sc_main_dstrx3_io_power_disable(void);


### PR DESCRIPTION
This PR fixes the device initialization on DSTRX-3 driver.