### PR TITLE
github/workflow: Remove Python 3.9 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,6 @@ jobs:
           - tests/hwtest/main
           - tests/hwtest/adcs
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
         os:


### PR DESCRIPTION
Zephyr 3.7 LTS requires Python 3.10 or higher. Therefore, building with Python 3.9 is no longer supported. This commit removes Python 3.9 from the build targets to reflect this requirement.

Note: Ubuntu 20.04 ships with Python 3.8, which also doesn't meet Zephyr's minimum Python version requirement. Users on Ubuntu 20.04 will need to install Python 3.10 or newer manually to build Zephyr 3.7 LTS.