### PR TITLE
Fix csp port number for adcs syshk

### DIFF
--- a/tests/hwtest/main/src/syshk_test.c
+++ b/tests/hwtest/main/src/syshk_test.c
@@ -95,6 +95,7 @@ static int send_adcs_syshk(void)
 		/* Send ADCS HK to Ground */
 		/* TODO: This is workaround for send ADCS telemetry to GND */
 		packet->id.dst = CSP_ID_GND;
+		packet->id.dport = SYSHK_PORT;
 		LOG_INF("Send ADCS HK (src:%d dst:%d)", packet->id.src, packet->id.dst);
 		csp_send_direct(&packet->id, packet, NULL);
 

--- a/tests/hwtest/main/src/version.h
+++ b/tests/hwtest/main/src/version.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-#define MAIN_HWTEST_VERSION "0.2.3"
+#define MAIN_HWTEST_VERSION "0.2.4"


### PR DESCRIPTION
This commit fixes the destination port for ADCS telemetry via MAIN board.