### PR TITLE
github: workflow: build: Add Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,8 @@ jobs:
         python-version:
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
         os:
           - ubuntu-24.04
           - ubuntu-22.04


### PR DESCRIPTION
Python 3.13 is released on October 7, 2024. Add it along with 3.12.