### PR TITLE
drivers/spi: "Remove build error when SPI is not used

### DIFF
--- a/drivers/spi/CMakeLists.txt
+++ b/drivers/spi/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_amend()
-zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/spi)
-zephyr_library_sources_ifdef(CONFIG_SPI_SC_QSPI spi_sc.c)
+if(CONFIG_SPI)
+  zephyr_library_amend()
+  zephyr_library_include_directories(${ZEPHYR_BASE}/drivers/spi)
+  zephyr_library_sources_ifdef(CONFIG_SPI_SC_QSPI spi_sc.c)
+endif()


### PR DESCRIPTION
When building a zephyr sample that does not use the SPI driver, the following error occurs.

  CMake Error at xxx (target_include_directories):
  Cannot specify include directories for target "drivers__spi" which is not
  built by this project.

This commit removes this error.