### PR TITLE
drivers/misc/fpga: Move system register API from hwtest

### DIFF
--- a/drivers/misc/fpga/sc_fpgasys.c
+++ b/drivers/misc/fpga/sc_fpgasys.c
@@ -78,6 +78,26 @@ void sc_select_codemem(enum sc_codemem mem)
 	sys_write32(SCOBCA1_SYSREG_MAGIC | mem, SCOBCA1_SYSREG_CODEMSEL);
 }
 
+uint32_t sc_get_fpga_ip_ver(void)
+{
+	return sys_read32(SCOBCA1_SYSREG_VER);
+}
+
+uint32_t sc_get_fpga_build_hash(void)
+{
+	return sys_read32(SCOBCA1_SYSREG_BUILDINFO);
+}
+
+uint32_t sc_get_fpga_dna_1(void)
+{
+	return sys_read32(SCOBCA1_SYSREG_DNA1);
+}
+
+uint32_t sc_get_fpga_dna_2(void)
+{
+	return sys_read32(SCOBCA1_SYSREG_DNA1);
+}
+
 static int sc_fpgasys_init(void)
 {
 	return 0;

--- a/drivers/misc/fpga/sc_fpgasys.h
+++ b/drivers/misc/fpga/sc_fpgasys.h
@@ -18,6 +18,10 @@ enum sc_cfgmem {
 	SC_CFG_MEM_1 = 1,
 };
 
+uint32_t sc_get_fpga_ip_ver(void);
+uint32_t sc_get_fpga_build_hash(void);
+uint32_t sc_get_fpga_dna_1(void);
+uint32_t sc_get_fpga_dna_2(void);
 enum sc_cfgmem sc_get_boot_cfgmem(void);
 enum sc_cfgmem sc_get_cfgmem(void);
 int sc_select_cfgmem(enum sc_cfgmem);

--- a/tests/hwtest/adcs/src/main.c
+++ b/tests/hwtest/adcs/src/main.c
@@ -20,6 +20,9 @@
 #include "loop_test.h"
 #include "syshk_test.h"
 #include "data_nor.h"
+#include "sc_fpgaconf.h"
+#include "sc_fpgasys.h"
+#include "version.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adcs_main, CONFIG_SCSAT1_ADCS_LOG_LEVEL);
@@ -34,6 +37,17 @@ K_THREAD_STACK_DEFINE(cmd_thread_stack, 4096);
 static struct k_thread cmd_thread;
 static struct k_event exec_event;
 extern struct k_event loop_event;
+
+static void sc_adcs_print_fpga_ids(void)
+{
+	LOG_INF("* FSW Version       : %s", ADCS_HWTEST_VERSION);
+	LOG_INF("* Boot CFG Memory   : %d", sc_get_boot_cfgmem());
+	LOG_INF("* FPGA Boot Status  : 0x%x", sc_fpgaconf_get_bootsts());
+	LOG_INF("* IP Version        : %08x", sc_get_fpga_ip_ver());
+	LOG_INF("* Build Information : %08x", sc_get_fpga_build_hash());
+	LOG_INF("* Device DNA 1      : %08x", sc_get_fpga_dna_1());
+	LOG_INF("* Device DNA 2      : %08x",sc_get_fpga_dna_2());
+}
 
 static void cmd_handler(void *p1, void *p2, void *p3)
 {

--- a/tests/hwtest/adcs/src/sysmon.c
+++ b/tests/hwtest/adcs/src/sysmon.c
@@ -6,8 +6,6 @@
 
 #include <zephyr/kernel.h>
 #include "sysmon.h"
-#include "version.h"
-#include "sc_fpgaconf.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sysmon, CONFIG_SCSAT1_ADCS_LOG_LEVEL);
@@ -347,23 +345,6 @@ void sc_adcs_kick_wdt_timer(void)
 
 	reg = sys_read32(SC_ADCS_SYSMON_BASE_ADDR + SC_ADCS_SYSMON_WDOG_CTRL_OFFSET);
 	sys_write32(reg, SC_ADCS_SYSMON_BASE_ADDR + SC_ADCS_SYSMON_WDOG_CTRL_OFFSET);
-}
-
-void sc_adcs_print_fpga_ids(void)
-{
-	LOG_INF("* FSW Version       : %s", ADCS_HWTEST_VERSION);
-	LOG_INF("* Boot CFG Memory   : %d",
-		SC_ADCS_SYSREG_CFGBOOTMEM(
-			sys_read32(SC_ADCS_SYSREG_BASE_ADDR + SC_ADCS_SYSREG_CFGMEMCTL_OFFSET)));
-	LOG_INF("* FPGA Boot Status  : 0x%x", sc_fpgaconf_get_bootsts());
-	LOG_INF("* IP Version        : %08x",
-		sys_read32(SC_ADCS_SYSREG_BASE_ADDR + SC_ADCS_SYSREG_VER_OFFSET));
-	LOG_INF("* Build Information : %08x",
-		sys_read32(SC_ADCS_SYSREG_BASE_ADDR + SC_ADCS_SYSREG_BUILDINFO_OFFSET));
-	LOG_INF("* Device DNA 1      : %08x",
-		sys_read32(SC_ADCS_SYSREG_BASE_ADDR + SC_ADCS_SYSREG_DNA1_OFFSET));
-	LOG_INF("* Device DNA 2      : %08x",
-		sys_read32(SC_ADCS_SYSREG_BASE_ADDR + SC_ADCS_SYSREG_DNA2_OFFSET));
 }
 
 int sc_adcs_bhm_enable(void)

--- a/tests/hwtest/adcs/src/sysmon.h
+++ b/tests/hwtest/adcs/src/sysmon.h
@@ -36,7 +36,6 @@ enum xadc_cv_pos {
 };
 
 void sc_adcs_kick_wdt_timer(void);
-void sc_adcs_print_fpga_ids(void);
 int sc_adcs_bhm_enable(void);
 int sc_adcs_bhm_disable(void);
 int sc_adcs_bhm_get_obc_temp(enum obc_temp_pos pos, float *temp);

--- a/tests/hwtest/main/src/main.c
+++ b/tests/hwtest/main/src/main.c
@@ -23,6 +23,9 @@
 #include "loop_test.h"
 #include "syshk_test.h"
 #include "data_nor.h"
+#include "sc_fpgaconf.h"
+#include "sc_fpgasys.h"
+#include "version.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_SCSAT1_MAIN_LOG_LEVEL);
@@ -37,6 +40,17 @@ K_THREAD_STACK_DEFINE(cmd_thread_stack, 2048);
 static struct k_thread cmd_thread;
 static struct k_event exec_event;
 extern struct k_event loop_event;
+
+static void sc_main_print_fpga_ids(void)
+{
+	LOG_INF("* FSW Version       : %s", MAIN_HWTEST_VERSION);
+	LOG_INF("* Boot CFG Memory   : %d", sc_get_boot_cfgmem());
+	LOG_INF("* FPGA Boot Status  : 0x%x", sc_fpgaconf_get_bootsts());
+	LOG_INF("* IP Version        : %08x", sc_get_fpga_ip_ver());
+	LOG_INF("* Build Information : %08x", sc_get_fpga_build_hash());
+	LOG_INF("* Device DNA 1      : %08x", sc_get_fpga_dna_1());
+	LOG_INF("* Device DNA 2      : %08x",sc_get_fpga_dna_2());
+}
 
 static void cmd_handler(void *p1, void *p2, void *p3)
 {

--- a/tests/hwtest/main/src/sysmon.c
+++ b/tests/hwtest/main/src/sysmon.c
@@ -6,14 +6,11 @@
 
 #include <zephyr/kernel.h>
 #include "sysmon.h"
-#include "version.h"
-#include "sc_fpgaconf.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sysmon, CONFIG_SCSAT1_MAIN_LOG_LEVEL);
 
 /* Registers */
-#define SC_MAIN_SYSREG_BASE_ADDR (0x4F000000) /* System Register */
 #define SC_MAIN_SYSMON_BASE_ADDR (0x4F040000) /* Systemo Monitor */
 #define SC_MAIN_GPT_BASE_ADDR    (0x4F050000) /* General Purpose Timer */
 
@@ -335,23 +332,6 @@ void sc_main_kick_wdt_timer(void)
 
 	reg = sys_read32(SC_MAIN_SYSMON_BASE_ADDR + SC_MAIN_SYSMON_WDOG_CTRL_OFFSET);
 	sys_write32(reg, SC_MAIN_SYSMON_BASE_ADDR + SC_MAIN_SYSMON_WDOG_CTRL_OFFSET);
-}
-
-void sc_main_print_fpga_ids(void)
-{
-	LOG_INF("* FSW Version       : %s", MAIN_HWTEST_VERSION);
-	LOG_INF("* Boot CFG Memory   : %d",
-		SC_MAIN_SYSREG_CFGBOOTMEM(
-			sys_read32(SC_MAIN_SYSREG_BASE_ADDR + SC_MAIN_SYSREG_CFGMEMCTL_OFFSET)));
-	LOG_INF("* FPGA Boot Status  : 0x%x", sc_fpgaconf_get_bootsts());
-	LOG_INF("* IP Version        : %08x",
-		sys_read32(SC_MAIN_SYSREG_BASE_ADDR + SC_MAIN_SYSREG_VER_OFFSET));
-	LOG_INF("* Build Information : %08x",
-		sys_read32(SC_MAIN_SYSREG_BASE_ADDR + SC_MAIN_SYSREG_BUILDINFO_OFFSET));
-	LOG_INF("* Device DNA 1      : %08x",
-		sys_read32(SC_MAIN_SYSREG_BASE_ADDR + SC_MAIN_SYSREG_DNA1_OFFSET));
-	LOG_INF("* Device DNA 2      : %08x",
-		sys_read32(SC_MAIN_SYSREG_BASE_ADDR + SC_MAIN_SYSREG_DNA2_OFFSET));
 }
 
 int sc_main_bhm_enable(void)

--- a/tests/hwtest/main/src/sysmon.h
+++ b/tests/hwtest/main/src/sysmon.h
@@ -36,7 +36,6 @@ enum xadc_cv_pos {
 };
 
 void sc_main_kick_wdt_timer(void);
-void sc_main_print_fpga_ids(void);
 int sc_main_bhm_enable(void);
 int sc_main_bhm_disable(void);
 int sc_main_bhm_get_obc_temp(enum obc_temp_pos pos, float *temp);


### PR DESCRIPTION
This commit moves the API for retrieving information from the FPGA System Register to the already implemented FPGA sys driver.