### PR TITLE
main,adcs: Change to use Kconfig for CSP thread

### DIFF
--- a/adcs/Kconfig
+++ b/adcs/Kconfig
@@ -6,6 +6,34 @@ module = SCSAT1_ADCS
 module-str = SC-Sat1 ADCS Board
 source "subsys/logging/Kconfig.template.log_config"
 
+menu "Thread"
+
+config SCSAT1_ADCS_CSP_ROUTER_THREAD_PRIORITY
+	int "CSP router thread priority"
+	default 0
+	help
+	  CSP router thread priority.
+
+config SCSAT1_ADCS_CSP_ROUTER_THREAD_STACK_SIZE
+	int "CSP router thread stack size"
+	default 256
+	help
+	  CSP router thread stack size.
+
+config SCSAT1_ADCS_CSP_SERVER_THREAD_PRIORITY
+	int "CSP server thread priority"
+	default 0
+	help
+	  CSP server thread priority.
+
+config SCSAT1_ADCS_CSP_SERVER_THREAD_STACK_SIZE
+	int "CSP server thread stack size"
+	default 1024
+	help
+	  CSP server thread stack size.
+
+endmenu
+
 endmenu
 
 menu "Zephyr"

--- a/adcs/src/csp.c
+++ b/adcs/src/csp.c
@@ -15,11 +15,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(csp, CONFIG_SCSAT1_ADCS_LOG_LEVEL);
 
-#define ROUTER_STACK_SIZE (256U)
-#define SERVER_STACK_SIZE (1024U)
-#define ROUTER_PRIO       (0U)
-#define SERVER_PRIO       (0U)
-
 static csp_iface_t *can_iface = NULL;
 
 static void *router_task(void *param)
@@ -41,10 +36,10 @@ static void *server_task(void *p1, void *p2, void *p3)
 
 	return NULL; }
 
-K_THREAD_DEFINE(router_id, ROUTER_STACK_SIZE, router_task, NULL, NULL, NULL, ROUTER_PRIO, 0,
-		K_TICKS_FOREVER);
-K_THREAD_DEFINE(server_id, SERVER_STACK_SIZE, server_task, NULL, NULL, NULL, SERVER_PRIO, 0,
-		K_TICKS_FOREVER);
+K_THREAD_DEFINE(router_id, CONFIG_SCSAT1_ADCS_CSP_ROUTER_THREAD_STACK_SIZE, router_task, NULL, NULL,
+		NULL, CONFIG_SCSAT1_ADCS_CSP_ROUTER_THREAD_PRIORITY, 0, K_TICKS_FOREVER);
+K_THREAD_DEFINE(server_id, CONFIG_SCSAT1_ADCS_CSP_SERVER_THREAD_STACK_SIZE, server_task, NULL, NULL,
+		NULL, CONFIG_SCSAT1_ADCS_CSP_SERVER_THREAD_PRIORITY, 0, K_TICKS_FOREVER);
 
 static void router_start(void)
 {

--- a/main/Kconfig
+++ b/main/Kconfig
@@ -6,6 +6,34 @@ module = SCSAT1_MAIN
 module-str = SC-Sat1 Main Board
 source "subsys/logging/Kconfig.template.log_config"
 
+menu "Thread"
+
+config SCSAT1_MAIN_CSP_ROUTER_THREAD_PRIORITY
+	int "CSP router thread priority"
+	default 0
+	help
+	  CSP router thread priority.
+
+config SCSAT1_MAIN_CSP_ROUTER_THREAD_STACK_SIZE
+	int "CSP router thread stack size"
+	default 1024
+	help
+	  CSP router thread stack size.
+
+config SCSAT1_MAIN_CSP_SERVER_THREAD_PRIORITY
+	int "CSP server thread priority"
+	default 0
+	help
+	  CSP server thread priority.
+
+config SCSAT1_MAIN_CSP_SERVER_THREAD_STACK_SIZE
+	int "CSP server thread stack size"
+	default 1024
+	help
+	  CSP server thread stack size.
+
+endmenu
+
 endmenu
 
 menu "Zephyr"

--- a/main/src/csp.c
+++ b/main/src/csp.c
@@ -16,11 +16,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(csp, CONFIG_SCSAT1_MAIN_LOG_LEVEL);
 
-#define ROUTER_STACK_SIZE (1024U)
-#define SERVER_STACK_SIZE (1024U)
-#define ROUTER_PRIO       (0U)
-#define SERVER_PRIO       (0U)
-
 static csp_iface_t *can_iface1 = NULL;
 static csp_iface_t *can_iface2 = NULL;
 
@@ -44,10 +39,10 @@ static void *server_task(void *p1, void *p2, void *p3)
 	return NULL;
 }
 
-K_THREAD_DEFINE(router_id, ROUTER_STACK_SIZE, router_task, NULL, NULL, NULL, ROUTER_PRIO, 0,
-		K_TICKS_FOREVER);
-K_THREAD_DEFINE(server_id, SERVER_STACK_SIZE, server_task, NULL, NULL, NULL, SERVER_PRIO, 0,
-		K_TICKS_FOREVER);
+K_THREAD_DEFINE(router_id, CONFIG_SCSAT1_MAIN_CSP_ROUTER_THREAD_STACK_SIZE, router_task, NULL, NULL,
+		NULL, CONFIG_SCSAT1_MAIN_CSP_ROUTER_THREAD_PRIORITY, 0, K_TICKS_FOREVER);
+K_THREAD_DEFINE(server_id, CONFIG_SCSAT1_MAIN_CSP_SERVER_THREAD_STACK_SIZE, server_task, NULL, NULL,
+		NULL, CONFIG_SCSAT1_MAIN_CSP_SERVER_THREAD_PRIORITY, 0, K_TICKS_FOREVER);
 
 static void router_start(void)
 {


### PR DESCRIPTION
Previously, the CSP router/server thread settings were defined in source code, but this commit changes it to allow configuration via Kconfig.