### PR TITLE
main,adcs: Fix unexpected reply telemetry

### DIFF
--- a/adcs/src/cmd/tlm.c
+++ b/adcs/src/cmd/tlm.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(tlm, CONFIG_SCSAT1_ADCS_LOG_LEVEL);
 
 int csp_tlm_handler(csp_packet_t *packet)
 {
-	int ret;
+	int ret = 0;
 	uint8_t command_id;
 
 	if (packet == NULL) {

--- a/main/src/cmd/tlm.c
+++ b/main/src/cmd/tlm.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(tlm, CONFIG_SCSAT1_MAIN_LOG_LEVEL);
 
 int csp_tlm_handler(csp_packet_t *packet)
 {
-	int ret;
+	int ret = 0;
 	uint8_t command_id;
 
 	if (packet == NULL) {


### PR DESCRIPTION
When a one-shot request for system HK telemetry, the reply telemetry, which includes an error code, is also downlinked along with the system HK telemetry. This is because a reply intended for an abnormal
 command code is mistakenly sent. This commit fixes the issue.