### PR TITLE
CSP counter limit to ground command

### DIFF
--- a/adcs/src/cmd/handler.c
+++ b/adcs/src/cmd/handler.c
@@ -24,18 +24,6 @@ LOG_MODULE_REGISTER(handler, CONFIG_SCSAT1_ADCS_LOG_LEVEL);
 
 struct csp_stat csp_stat = {0};
 
-static void update_csp_stat(csp_packet_t *packet)
-{
-	csp_stat.received_command_count++;
-	csp_stat.last_csp_port = packet->id.dport;
-
-	if (packet->length > 0) {
-		csp_stat.last_command_id = packet->data[CSP_COMMAND_ID_OFFSET];
-	} else {
-		csp_stat.last_command_id = CSP_UNKNOWN_CMD_CODE;
-	}
-}
-
 void csp_cmd_handler(void)
 {
 	LOG_INF("CSP command handler task started");
@@ -55,7 +43,7 @@ void csp_cmd_handler(void)
 
 		csp_packet_t *packet;
 		while ((packet = csp_read(conn, 50)) != NULL) {
-			update_csp_stat(packet);
+			csp_system_update_stat(packet, &csp_stat);
 			switch (csp_conn_dport(conn)) {
 			case CSP_PORT_ADCS_PWRCTRL:
 				csp_pwrctrl_handler(packet);

--- a/adcs/src/cmd/handler.h
+++ b/adcs/src/cmd/handler.h
@@ -6,10 +6,4 @@
 
 #pragma once
 
-struct csp_stat {
-	uint16_t received_command_count;
-	uint8_t last_csp_port;
-	uint8_t last_command_id;
-};
-
 void csp_cmd_handler(void);

--- a/adcs/src/mon/system.c
+++ b/adcs/src/mon/system.c
@@ -10,6 +10,7 @@
 #include "system.h"
 #include "handler.h"
 #include "fram.h"
+#include "sys.h"
 #include "pwrctrl_adcs.h"
 #include "sc_fpgaconf.h"
 #include "sc_fpgahrmem.h"

--- a/lib/csp/sys.c
+++ b/lib/csp/sys.c
@@ -8,6 +8,7 @@
 #include "sc_csp.h"
 #include "reply.h"
 #include "fram.h"
+#include "sys.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sys_handler, CONFIG_SC_LIB_CSP_LOG_LEVEL);
@@ -70,4 +71,16 @@ free:
 
 end:
 	return ret;
+}
+
+void csp_system_update_stat(csp_packet_t *packet, struct csp_stat *stat)
+{
+	stat->received_command_count++;
+	stat->last_csp_port = packet->id.dport;
+
+	if (packet->length > 0) {
+		stat->last_command_id = packet->data[CSP_COMMAND_ID_OFFSET];
+	} else {
+		stat->last_command_id = CSP_UNKNOWN_CMD_CODE;
+	}
 }

--- a/lib/csp/sys.c
+++ b/lib/csp/sys.c
@@ -75,6 +75,11 @@ end:
 
 void csp_system_update_stat(csp_packet_t *packet, struct csp_stat *stat)
 {
+	/* Pings from the EPS are not counted */
+	if (packet->id.src != CSP_ID_GND) {
+		goto end;
+	}
+
 	stat->received_command_count++;
 	stat->last_csp_port = packet->id.dport;
 
@@ -83,4 +88,7 @@ void csp_system_update_stat(csp_packet_t *packet, struct csp_stat *stat)
 	} else {
 		stat->last_command_id = CSP_UNKNOWN_CMD_CODE;
 	}
+
+end:
+	return;
 }

--- a/lib/csp/sys.h
+++ b/lib/csp/sys.h
@@ -8,4 +8,11 @@
 
 #include <csp/csp.h>
 
+struct csp_stat {
+	uint16_t received_command_count;
+	uint8_t last_csp_port;
+	uint8_t last_command_id;
+};
+
 int csp_system_handler(csp_packet_t *packet);
+void csp_system_update_stat(csp_packet_t *packet, struct csp_stat *stat);

--- a/main/src/cmd/handler.c
+++ b/main/src/cmd/handler.c
@@ -24,18 +24,6 @@ LOG_MODULE_REGISTER(handler, CONFIG_SCSAT1_MAIN_LOG_LEVEL);
 
 struct csp_stat csp_stat = {0};
 
-static void update_csp_stat(csp_packet_t *packet)
-{
-	csp_stat.received_command_count++;
-	csp_stat.last_csp_port = packet->id.dport;
-
-	if (packet->length > 0) {
-		csp_stat.last_command_id = packet->data[CSP_COMMAND_ID_OFFSET];
-	} else {
-		csp_stat.last_command_id = CSP_UNKNOWN_CMD_CODE;
-	}
-}
-
 void csp_cmd_handler(void)
 {
 	LOG_INF("CSP command handler task started");
@@ -55,7 +43,7 @@ void csp_cmd_handler(void)
 
 		csp_packet_t *packet;
 		while ((packet = csp_read(conn, 50)) != NULL) {
-			update_csp_stat(packet);
+			csp_system_update_stat(packet, &csp_stat);
 			switch (csp_conn_dport(conn)) {
 			case CSP_PORT_MAIN_PWRCTRL:
 				csp_pwrctrl_handler(packet);

--- a/main/src/cmd/handler.h
+++ b/main/src/cmd/handler.h
@@ -6,10 +6,4 @@
 
 #pragma once
 
-struct csp_stat {
-	uint16_t received_command_count;
-	uint8_t last_csp_port;
-	uint8_t last_command_id;
-};
-
 void csp_cmd_handler(void);

--- a/main/src/mon/system.c
+++ b/main/src/mon/system.c
@@ -10,6 +10,7 @@
 #include "system.h"
 #include "handler.h"
 #include "fram.h"
+#include "sys.h"
 #include "pwrctrl_main.h"
 #include "sc_fpgaconf.h"
 #include "sc_fpgahrmem.h"


### PR DESCRIPTION
Currently, the CSP command received counter does not specifically check the source, so monitoring pings periodically sent from the EPS are being included in the count. in this commit, it is limit to CSP commands from the Ground only.

