### PR TITLE
Add erase data nor command

### DIFF
--- a/lib/flash/data_nor.h
+++ b/lib/flash/data_nor.h
@@ -8,3 +8,4 @@
 
 int datafs_init(void);
 int update_boot_count(const char *fname);
+int data_nor_erase(uint8_t id);


### PR DESCRIPTION
This commit adds an erase API for the NOR flash partition used for data storage. The NOR flash for data storage has two banks, but currently, only one bank is usable. Therefore, Erase will only support the bank in use.
    
