### PR TITLE
lib: csp: Fix release leak when file operation

### DIFF
--- a/lib/csp/file.c
+++ b/lib/csp/file.c
@@ -397,6 +397,7 @@ int csp_file_handler(csp_packet_t *packet)
 	if (file_work == NULL) {
 		LOG_ERR("File operation work queue is busy");
 		ret = -EBUSY;
+		csp_buffer_free(packet);
 		goto end;
 	}
 


### PR DESCRIPTION
Fixes an issue where the received CSP packet was not being released when the file operation workqueue is busy.