### PR TITLE
adcs: Remove VDD 12V CV for ADCS System HK

### DIFF
--- a/adcs/src/mon/cv.c
+++ b/adcs/src/mon/cv.c
@@ -35,10 +35,6 @@ static void cv_monitor(struct k_work *work)
 		ADCS_VDD_3V3_IMU_SHUNT, ADCS_VDD_3V3_IMU_BUS,   ADCS_VDD_3V3_GPS_SHUNT,
 		ADCS_VDD_3V3_GPS_BUS,   ADCS_VDD_3V3_DRV_SHUNT, ADCS_VDD_3V3_DRV_BUS,
 	};
-	enum rw_cv_pos rw_pos_list[] = {
-		ADCS_VDD_12V_DRVX_SHUNT, ADCS_VDD_12V_DRVX_BUS,   ADCS_VDD_12V_DRVY_SHUNT,
-		ADCS_VDD_12V_DRVY_BUS,   ADCS_VDD_12V_DRVZ_SHUNT, ADCS_VDD_12V_DRVZ_BUS,
-	};
 
 	for (pos = 0; pos < ARRAY_SIZE(obc_pos_list); pos++) {
 		msg.obc[pos].status = sc_bhm_get_obc_cv(obc_pos_list[pos], &msg.obc[pos].cv);
@@ -58,13 +54,6 @@ static void cv_monitor(struct k_work *work)
 		msg.adcs[pos].status = get_adcs_cv(adcs_pos_list[pos], &msg.adcs[pos].cv);
 		if (msg.adcs[pos].status < 0) {
 			msg.adcs[pos].cv = CV_INVALID_INT;
-		}
-	}
-
-	for (pos = 0; pos < ARRAY_SIZE(rw_pos_list); pos++) {
-		msg.rw[pos].status = get_rw_cv(rw_pos_list[pos], &msg.rw[pos].cv);
-		if (msg.rw[pos].status < 0) {
-			msg.rw[pos].cv = CV_INVALID_INT;
 		}
 	}
 

--- a/adcs/src/mon/cv.h
+++ b/adcs/src/mon/cv.h
@@ -23,7 +23,6 @@ struct cv_msg {
 	struct cv_int32_entry obc[OBC_CV_POS_NUM];
 	struct cv_float_entry xadc[OBC_XADC_CV_POS_NUM];
 	struct cv_int32_entry adcs[ADCS_CV_POS_NUM];
-	struct cv_float_entry rw[ADCS_RW_CV_POS_NUM];
 };
 
 void start_cv_monitor(void);

--- a/adcs/src/tlm/syshk.c
+++ b/adcs/src/tlm/syshk.c
@@ -28,7 +28,7 @@ ZBUS_SUBSCRIBER_DEFINE(syshk_sub, CONFIG_SCSAT1_ADCS_SYSHK_SUB_QUEUE_SIZE);
 
 #define SYSHK_SYSTEM_BLOCK_SIZE (33U)
 #define SYSHK_TEMP_BLOCK_SIZE   (35U)
-#define SYSHK_CV_BLOCK_SIZE     (135U)
+#define SYSHK_CV_BLOCK_SIZE     (105U)
 
 struct syshk_tlm {
 	uint8_t telemetry_id;
@@ -123,13 +123,6 @@ static void copy_cv_to_syshk(struct cv_msg *msg)
 		cv_block += sizeof(msg->adcs[pos].status);
 		memcpy(cv_block, &msg->adcs[pos].cv, sizeof(msg->adcs[pos].cv));
 		cv_block += sizeof(msg->adcs[pos].cv);
-	}
-
-	for (pos = 0; pos < ADCS_RW_CV_POS_NUM; pos++) {
-		memcpy(cv_block, &msg->rw[pos].status, sizeof(msg->rw[pos].status));
-		cv_block += sizeof(msg->rw[pos].status);
-		memcpy(cv_block, &msg->rw[pos].cv, sizeof(msg->rw[pos].cv));
-		cv_block += sizeof(msg->rw[pos].cv);
 	}
 }
 


### PR DESCRIPTION
The 12V VDD will not be used in our initial operations, and the 3V3 DRV, which serves as the power supply for the CV monitor we monitor, will also not be enabled. Therefore, it will be removed from the System HK during the initial operations.