### PR TITLE
lib/flash: Workaround of Config NOR bank1 issue

### DIFF
--- a/adcs/src/main.c
+++ b/adcs/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include "csp.h"
 #include "wdog.h"
+#include "config_nor.h"
 #include "data_nor.h"
 #include "fram.h"
 #include "syshk.h"
@@ -18,6 +19,7 @@ int main(void)
 	start_kick_wdt_thread();
 
 	datafs_init();
+	sc_config_nor_set_addr_mode();
 
 	sc_fram_update_boot_count();
 

--- a/lib/flash/config_nor.h
+++ b/lib/flash/config_nor.h
@@ -10,3 +10,4 @@
 
 int sc_config_nor_erase(uint8_t bank, uint8_t id, off_t offset, size_t size);
 int sc_config_nor_calc_crc(uint8_t bank, uint8_t id, off_t offset, size_t size, uint32_t *crc32);
+void sc_config_nor_set_addr_mode(void);

--- a/main/src/main.c
+++ b/main/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include "csp.h"
 #include "wdog.h"
+#include "config_nor.h"
 #include "data_nor.h"
 #include "fram.h"
 #include "pwrctrl_main.h"
@@ -19,6 +20,7 @@ int main(void)
 	start_kick_wdt_thread();
 
 	datafs_init();
+	sc_config_nor_set_addr_mode();
 
 	sc_fram_update_boot_count();
 


### PR DESCRIPTION
SC-Sat1 has two Configuration NOR flash memory banks (bank0/bank1). Normally, FPGA configuration is performed from bank0, and the FSW (Flight Software) also boots from the same bank.

However, when an FSW booted from bank0 executes operations such as erasing NOR flash on bank1, the device appears to ignore the erase command.

This issue occurs because the NOR flash used in SC-Sat1 has a capacity of 32MB, requiring the 4-byte address access mode to be configured on the NOR flash. However, this mode is not set for the NOR flash on the bank1 side.

The 4-byte address mode is set only during the initialization of the spi-nor driver. When the FSW is booted from bank0, the NOR flash on the disconnected bank1 side does not have this setting applied.

As a workaround for this issue, this commit introduces initialization processing in the FSW that configures the 4-byte address mode for both bank0 and bank1.

As a permanent solution, a broader review, including updates to the spi-nor driver, should be considered to determine the best approach to resolve this issue.

 Issue: #99