### PR TITLE
lib/csp: Increase parameters for File Upload feature

### DIFF
--- a/lib/csp/CMakeLists.txt
+++ b/lib/csp/CMakeLists.txt
@@ -12,6 +12,6 @@ zephyr_library_sources_ifdef(CONFIG_SC_LIB_CSP upload.c)
 
 zephyr_include_directories(.)
 
-set(CSP_BUFFER_COUNT 50 CACHE STRING "Number of total packet buffers")
-set(CSP_QFIFO_LEN 50 CACHE STRING "Length of incoming queue for router task")
+set(CSP_BUFFER_COUNT 1000 CACHE STRING "Number of total packet buffers")
+set(CSP_QFIFO_LEN 1000 CACHE STRING "Length of incoming queue for router task")
 zephyr_link_libraries(libcsp)

--- a/lib/csp/Kconfig
+++ b/lib/csp/Kconfig
@@ -42,7 +42,7 @@ config SC_LIB_CSP_FILE_THREAD_STACK_SIZE
 
 config SC_LIB_CSP_MAX_FILE_WORK
 	int "MAX number of file operation work"
-	default 50
+	default 1000
 	help
 	  MAX number of file operation work.
 


### PR DESCRIPTION
Currently, during File Upload, we have faced that when data packets are missing, and LittleFS attempts to write data to an offset larger than the current file size, a process is triggered to copy previously written block data to a new block. This copying process can take up to about 7 seconds.

During this time, CSP packets accumulate in the libcsp buffer without being released, causing the application to stuck. We will investigate the root cause of the stucking issue further, but as a workaround, we will increase the FIFO-related settings in libcsp and th eapplication's work queue size.

These values are provisional for testing purposes. However, even with this commit applied, memory usage remains at around 11%.