### PR TITLE
lib/csp: Add Read FPGA register command

### DIFF
--- a/lib/csp/sys.h
+++ b/lib/csp/sys.h
@@ -14,5 +14,11 @@ struct csp_stat {
 	uint8_t last_command_id;
 };
 
+struct system_reg_telemetry {
+	uint8_t telemetry_id;
+	uint32_t error_code;
+	uint32_t reg_value;
+} __attribute__((__packed__));
+
 int csp_system_handler(csp_packet_t *packet);
 void csp_system_update_stat(csp_packet_t *packet, struct csp_stat *stat);


### PR DESCRIPTION
This commit adds a command to read the address of an arbitrary FPGA register and return the value to the ground.