### PR TITLE
lib/csp: Fix argument offset for Config Memory operations

### DIFF
--- a/lib/csp/flash.c
+++ b/lib/csp/flash.c
@@ -32,9 +32,9 @@ LOG_MODULE_REGISTER(sc_flash, CONFIG_SC_LIB_CSP_LOG_LEVEL);
 /* Command argument offset */
 #define FLASH_CFG_BANK_OFFSET (1U)
 #define FLASH_CFG_PID_OFFET   (2U)
-#define FLASH_CFG_FRAM_OFFET  (3U)
-#define FLASH_CFG_OFST_OFFSET (4U)
-#define FLASH_CFG_SIZE_OFFSET (8U)
+#define FLASH_CFG_OFST_OFFSET (3U)
+#define FLASH_CFG_SIZE_OFFSET (7U)
+#define FLASH_CFG_FRAM_OFFET  (11U)
 #define FLASH_DATA_PID_OFFET  (1U)
 
 #define UNKOWN_COMMAND_ID (0xFF)
@@ -155,9 +155,9 @@ static int csp_flash_calc_crc_cmd(uint8_t command_id, csp_packet_t *packet)
 
 	bank = packet->data[FLASH_CFG_BANK_OFFSET];
 	partition_id = packet->data[FLASH_CFG_PID_OFFET];
-	fram_opt = packet->data[FLASH_CFG_FRAM_OFFET];
 	offset = sys_le32_to_cpu(*(uint32_t *)&packet->data[FLASH_CFG_OFST_OFFSET]);
 	size = sys_le32_to_cpu(*(uint32_t *)&packet->data[FLASH_CFG_SIZE_OFFSET]);
+	fram_opt = packet->data[FLASH_CFG_FRAM_OFFET];
 
 	LOG_INF("Calculate CRC32 command (bank: %d) (partition_id: %d) (offset: %ld) (size: %d)",
 		bank, partition_id, offset, size);


### PR DESCRIPTION
Fix an issue where the command argument offset for FLASH_CFG_ERASE_CMD was incorrect with commit below.

    commit cbded7b611ff01e6c6c933ae3da34b4265584cd6
    Author: Takuya Sasaki <takuya.sasaki@spacecubics.com>
    Date:   Sat Nov 23 21:05:53 2024 +0900

    lib/csp: Add FRAM save option to Config Memory CRC