### PR TITLE
lib/csp: Tune parameter for File Upload feature

### DIFF
--- a/lib/csp/CMakeLists.txt
+++ b/lib/csp/CMakeLists.txt
@@ -12,6 +12,6 @@ zephyr_library_sources_ifdef(CONFIG_SC_LIB_CSP upload.c)
 
 zephyr_include_directories(.)
 
-set(CSP_BUFFER_COUNT 1000 CACHE STRING "Number of total packet buffers")
-set(CSP_QFIFO_LEN 1000 CACHE STRING "Length of incoming queue for router task")
+set(CSP_BUFFER_COUNT 300 CACHE STRING "Number of total packet buffers")
+set(CSP_QFIFO_LEN 300 CACHE STRING "Length of incoming queue for router task")
 zephyr_link_libraries(libcsp)

--- a/lib/csp/Kconfig
+++ b/lib/csp/Kconfig
@@ -42,7 +42,7 @@ config SC_LIB_CSP_FILE_THREAD_STACK_SIZE
 
 config SC_LIB_CSP_MAX_FILE_WORK
 	int "MAX number of file operation work"
-	default 1000
+	default 300
 	help
 	  MAX number of file operation work.
 


### PR DESCRIPTION
The parameter increased in the following commit will be changed to 300 to help reduce the increase in binary size.

  commit 9ba78c8
    lib/csp: Increase parameters for File Upload feature