### PR TITLE
Fix power disable for adcs

### DIFF
--- a/adcs/src/version.h
+++ b/adcs/src/version.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-#define ADCS_FSW_VERSION "1.0.0"
+#define ADCS_FSW_VERSION "1.0.1"

--- a/lib/core/pwrctrl_adcs.c
+++ b/lib/core/pwrctrl_adcs.c
@@ -34,7 +34,10 @@ void sc_adcs_power_enable(uint8_t target_bit)
 
 void sc_adcs_power_disable(uint8_t target_bit)
 {
-	sys_clear_bits(SCADCS_ADCS_BASE_ADDR + SCADCS_PCR_OFFSET, SCADCS_PCR_KEYCODE | target_bit);
+	uint32_t val = sys_read32(SCADCS_ADCS_BASE_ADDR + SCADCS_PCR_OFFSET);
+
+	val = SCADCS_PCR_KEYCODE | (val & ~target_bit);
+	sys_write32(val, SCADCS_ADCS_BASE_ADDR + SCADCS_PCR_OFFSET);
 }
 
 void sc_adcs_imu_reset(void)


### PR DESCRIPTION
Fixes an issue where disabling the power control for ADCS was not working correctly. This issue had been resolved on the MAIN board in the following commit but had not been deployed to ADCS.

commit https://github.com/spacecubics/scsat1-fsw/commit/f97719a85d901e016e08d062a84f7cfa339af8b0
    hwtest/main: Fix Power disable not working